### PR TITLE
fix: Fix critical bugs in iOS coverUrl handling, Android JVM compatibility, and Manifest generation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,17 +38,31 @@ buildscript {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 33)
+  compileSdkVersion safeExtGet("compileSdkVersion", 34)
 
+  // 根据 AGP 版本设置合适的 JVM 版本，确保兼容性
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
-    compileOptions {
+  def agpMajorVersion = agpVersion.tokenize('.')[0].toInteger()
+  
+  compileOptions {
+    if (agpMajorVersion >= 8) {
+      // AGP 8.0+ 使用 Java 17
+      sourceCompatibility JavaVersion.VERSION_17
+      targetCompatibility JavaVersion.VERSION_17
+    } else {
+      // AGP 7.x 及以下使用 Java 11
       sourceCompatibility JavaVersion.VERSION_11
       targetCompatibility JavaVersion.VERSION_11
     }
+  }
 
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_11.majorVersion
+  kotlinOptions {
+    if (agpMajorVersion >= 8) {
+      // AGP 8.0+ 使用 Java 17
+      jvmTarget = JavaVersion.VERSION_17.toString()
+    } else {
+      // AGP 7.x 及以下使用 Java 11
+      jvmTarget = JavaVersion.VERSION_11.toString()
     }
   }
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -95,35 +95,69 @@ const withNativeWechatConfig = (config) => {
     const androidManifest = config.modResults;
     const packageName = config.android?.package;
 
-    config.modResults.manifest.queries.push({
-      package: [
-        {
-          $: {
-            "android:name": "com.tencent.mm",
+    // 检查是否已经存在 queries 标签
+    if (!config.modResults.manifest.queries) {
+      config.modResults.manifest.queries = [];
+    }
+
+    // 检查是否已经添加了微信包查询，避免重复添加
+    const existingWechatQuery = config.modResults.manifest.queries.find(query => 
+      query.package && query.package.some(pkg => 
+        pkg.$ && pkg.$["android:name"] === "com.tencent.mm"
+      )
+    );
+
+    if (!existingWechatQuery) {
+      config.modResults.manifest.queries.push({
+        package: [
+          {
+            $: {
+              "android:name": "com.tencent.mm",
+            },
           },
-        },
-      ],
-    });
+        ],
+      });
+    }
 
     const mainApplication = getMainApplicationOrThrow(androidManifest);
 
-    mainApplication.activity?.push({
-      $: {
-        "android:name": ".wxapi.WXEntryActivity",
-        "android:label": "@string/app_name",
-        "android:theme": "@android:style/Theme.Translucent.NoTitleBar",
-        "android:exported": "true",
-        "android:taskAffinity": packageName,
-        "android:launchMode": "singleTask",
-      },
-    });
-    mainApplication.activity?.push({
-      $: {
-        "android:name": ".wxapi.WXPayEntryActivity",
-        "android:exported": "true",
-        "android:label": "@string/app_name",
-      }
-    })
+    // 确保 activity 数组存在
+    if (!mainApplication.activity) {
+      mainApplication.activity = [];
+    }
+
+    // 检查是否已经添加了 WXEntryActivity，避免重复添加
+    const existingWXEntryActivity = mainApplication.activity.find(activity => 
+      activity.$ && activity.$["android:name"] === ".wxapi.WXEntryActivity"
+    );
+
+    if (!existingWXEntryActivity) {
+      mainApplication.activity.push({
+        $: {
+          "android:name": ".wxapi.WXEntryActivity",
+          "android:label": "@string/app_name",
+          "android:theme": "@android:style/Theme.Translucent.NoTitleBar",
+          "android:exported": "true",
+          "android:taskAffinity": packageName,
+          "android:launchMode": "singleTask",
+        },
+      });
+    }
+
+    // 检查是否已经添加了 WXPayEntryActivity，避免重复添加
+    const existingWXPayEntryActivity = mainApplication.activity.find(activity => 
+      activity.$ && activity.$["android:name"] === ".wxapi.WXPayEntryActivity"
+    );
+
+    if (!existingWXPayEntryActivity) {
+      mainApplication.activity.push({
+        $: {
+          "android:name": ".wxapi.WXPayEntryActivity",
+          "android:exported": "true",
+          "android:label": "@string/app_name",
+        }
+      });
+    }
 
     return config;
   });

--- a/ios/ExpoNativeWechatModule.swift
+++ b/ios/ExpoNativeWechatModule.swift
@@ -168,10 +168,13 @@ public class ExpoNativeWechatModule: Module {
             }
             
             if params.coverUrl != nil {
-                let url = URL(string: params.coverUrl!)
+                guard let url = URL(string: params.coverUrl!) else {
+                    self.sendEvent("ResponseData", ["id": params.id, "success": false, "message": "Invalid cover URL"])
+                    return
+                }
                 
-                ExpoWechatUtils.downloadFile(url: url!) { data in
-                    if data == nil {
+                ExpoWechatUtils.downloadFile(url: url) { data in
+                    if data != nil {
                         let compressed = ExpoWechatUtils.compressImage(data: data!, limit: 32000)
                         
                         onCoverDownloaded(compressed)
@@ -214,10 +217,13 @@ public class ExpoNativeWechatModule: Module {
             }
             
             if params.coverUrl != nil {
-                let url = URL(string: params.coverUrl!)
+                guard let url = URL(string: params.coverUrl!) else {
+                    self.sendEvent("ResponseData", ["id": params.id, "success": false, "message": "Invalid cover URL"])
+                    return
+                }
                 
-                ExpoWechatUtils.downloadFile(url: url!) { data in
-                    if data == nil {
+                ExpoWechatUtils.downloadFile(url: url) { data in
+                    if data != nil {
                         let compressed = ExpoWechatUtils.compressImage(data: data!, limit: 32000)
                         
                         onCoverDownloaded(compressed)
@@ -264,10 +270,13 @@ public class ExpoNativeWechatModule: Module {
             }
             
             if params.coverUrl != nil {
-                let url = URL(string: params.coverUrl!)
+                guard let url = URL(string: params.coverUrl!) else {
+                    self.sendEvent("ResponseData", ["id": params.id, "success": false, "message": "Invalid cover URL"])
+                    return
+                }
                 
-                ExpoWechatUtils.downloadFile(url: url!) { data in
-                    if data == nil {
+                ExpoWechatUtils.downloadFile(url: url) { data in
+                    if data != nil {
                         let compressed = ExpoWechatUtils.compressImage(data: data!, limit: 32000)
                         
                         onCoverDownloaded(compressed)


### PR DESCRIPTION
### 🐛 Bug Fixes & Improvements

This PR contains **THREE** critical fixes for expo-native-wechat:

#### 1\. 🍎 **iOS: Fix critical logic error in coverUrl handling**

**Issue Location:** Lines 173-181, 219-227, and 269-277 in three functions:

* `shareVideo`
* `shareWebpage`
* `shareMiniProgram`

**Root Cause:** The condition logic for handling downloaded image data is inverted:

```swift
// ❌ WRONG - This will crash!
if data == nil {
    let compressed = ExpoWechatUtils.compressImage(data: data!, limit: 32000) // Force unwrap nil!
    onCoverDownloaded(compressed)
} else {
    onCoverDownloaded(nil) // Ignore valid data
}
```

**✅ FIXED:**

```swift
guard let url = URL(string: params.coverUrl!) else {
    self.sendEvent("ResponseData", ["id": params.id, "success": false, "message": "Invalid cover URL"])
    return
}

ExpoWechatUtils.downloadFile(url: url) { data in
    if data != nil {
        let compressed = ExpoWechatUtils.compressImage(data: data!, limit: 32000)
        onCoverDownloaded(compressed)
    } else {
        onCoverDownloaded(nil)
    }
}
```

#### 2\. 🤖 **Android: Fix JVM compatibility issues for AGP 8.0+**

**Issue:** JVM target compatibility error when building with Android Gradle Plugin 8.0+:

```
Inconsistent JVM-target compatibility detected for tasks 'compileReleaseJavaWithJavac' (17) and 'compileReleaseKotlin' (21).
```

**Root Cause:** The original AGP version check logic had a flaw:

* AGP < 8.0: Correctly set Java 11
* AGP >= 8.0: **No JVM version set** → caused version mismatch

**✅ FIXED:** Enhanced AGP version detection with explicit JVM target setting:

```kotlin
// 根据 AGP 版本设置合适的 JVM 版本，确保兼容性
def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
def agpMajorVersion = agpVersion.tokenize('.')[0].toInteger()

compileOptions {
  if (agpMajorVersion >= 8) {
    // AGP 8.0+ 使用 Java 17
    sourceCompatibility JavaVersion.VERSION_17
    targetCompatibility JavaVersion.VERSION_17
  } else {
    // AGP 7.x 及以下使用 Java 11
    sourceCompatibility JavaVersion.VERSION_11
    targetCompatibility JavaVersion.VERSION_11
  }
}

kotlinOptions {
  if (agpMajorVersion >= 8) {
    jvmTarget = JavaVersion.VERSION_17.toString()
  } else {
    jvmTarget = JavaVersion.VERSION_11.toString()
  }
}
```

#### 3\. ⚙️ **Android: Fix duplicate Android Manifest configuration in expo config plugin**

**Issue:** Multiple executions of `npx expo prebuild --platform android` cause duplicate entries in AndroidManifest.xml:

```xml
<!-- ❌ WRONG - Duplicated on each prebuild -->
<queries>
    <package android:name="com.tencent.mm"/>
</queries>
<queries>
    <package android:name="com.tencent.mm"/>
</queries>
<!-- ... more duplicates ... -->
```

**Root Cause:** The expo config plugin directly pushes new entries without checking for existing ones:

```javascript
// ❌ WRONG - Always adds without checking
config.modResults.manifest.queries.push({
  package: [{ $: { "android:name": "com.tencent.mm" } }]
});

mainApplication.activity?.push({
  $: { "android:name": ".wxapi.WXEntryActivity" }
});
```

**✅ FIXED:** Added existence checks to prevent duplicates:

```javascript
// 检查是否已经存在 queries 标签
if (!config.modResults.manifest.queries) {
  config.modResults.manifest.queries = [];
}

// 检查是否已经添加了微信包查询，避免重复添加
const existingWechatQuery = config.modResults.manifest.queries.find(query => 
  query.package && query.package.some(pkg => 
    pkg.$ && pkg.$["android:name"] === "com.tencent.mm"
  )
);

if (!existingWechatQuery) {
  config.modResults.manifest.queries.push({
    package: [{ $: { "android:name": "com.tencent.mm" } }]
  });
}

// Similar checks for WXEntryActivity and WXPayEntryActivity
const existingWXEntryActivity = mainApplication.activity.find(activity => 
  activity.$ && activity.$["android:name"] === ".wxapi.WXEntryActivity"
);

if (!existingWXEntryActivity) {
  mainApplication.activity.push({
    $: {
      "android:name": ".wxapi.WXEntryActivity",
      "android:label": "@string/app_name",
      "android:theme": "@android:style/Theme.Translucent.NoTitleBar",
      "android:exported": "true",
      "android:taskAffinity": packageName,
      "android:launchMode": "singleTask",
    },
  });
}
```

### 🎯 Combined Impact

**Before Fixes:**

* ❌ iOS: App crashes when coverUrl download fails
* ❌ iOS: Cover images never display even when download succeeds
* ❌ Android: Build fails with JVM compatibility errors on AGP 8.0+
* ❌ Android: Inconsistent JVM versions between Java and Kotlin compilation
* ❌ Android: Duplicate manifest entries on multiple prebuild executions
* ❌ Android: Polluted AndroidManifest.xml with repeated configurations

**After Fixes:**

* ✅ iOS: No more crashes, cover images display correctly
* ✅ iOS: Graceful error handling for invalid URLs
* ✅ Android: Seamless builds on both AGP 7.x and 8.0+
* ✅ Android: Backward compatible with older projects
* ✅ Android: Clean AndroidManifest.xml regardless of prebuild frequency
* ✅ Android: Stable expo config plugin behavior
* ✅ All platforms: Consistent, reliable behavior

### 🧪 Testing Matrix

| Scenario                      | iOS | Android (AGP 7.x) | Android (AGP 8.0+) |
| ----------------------------- | --- | ----------------- | ------------------ |
| Valid coverUrl               | ✅   | ✅                 | ✅                  |
| Invalid coverUrl             | ✅   | ✅                 | ✅                  |
| No coverUrl                  | ✅   | ✅                 | ✅                  |
| Build compatibility          | N/A | ✅ Java 11         | ✅ Java 17          |
| Single prebuild execution    | N/A | ✅ Clean manifest  | ✅ Clean manifest   |
| Multiple prebuild executions | N/A | ✅ No duplicates   | ✅ No duplicates    |

### 📋 Compatibility Matrix

| Project Setup         | Module JVM Version | Manifest Entries | Status       |
| --------------------- | ------------------ | --------------- | ------------ |
| AGP 7.x + Java 11     | Java 11            | Single entries  | ✅ Compatible |
| AGP 8.0+ + Java 17    | Java 17            | Single entries  | ✅ Compatible |
| AGP 8.0+ + Gradle 8.x | Java 17            | Single entries  | ✅ Compatible |

### 🔗 Related Issues

This PR addresses:

* Cover images not appearing in WeChat shares (iOS)
* App crashes when sharing content with cover URLs (iOS)
* Build failures with "Inconsistent JVM-target compatibility" (Android)
* Incompatibility with React Native 0.79+ and modern Android toolchain
* Duplicate AndroidManifest.xml entries on repeated prebuild executions
* Unstable expo config plugin behavior

---

**Note:** All three fixes are critical for production use and maintain full backward compatibility. No breaking changes to the API. 

