### PR TITLE
feat: Add WeChat App Pure Contract Signing Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ export type NativeWechatResponse<T = Record<string, unknown>> = {
 };
 ```
 
+## WeChat App Pure Contract Signing
+
+### appPureSignContract
+
+```typescript
+import { appPureSignContract } from 'expo-native-wechat';
+
+const signContract = async () => {
+  try {
+    const result = await appPureSignContract({
+      preEntrustwebId: '5778aadY9nltAsZzXixCkFIGYnV2V'
+    });
+    console.log('Contract signing result:', result);
+  } catch (error) {
+    console.error('Contract signing failed:', error);
+  }
+};
+```
+
 # Support
 
 If you have trouble using this library, do not hesitate to open an issue. I am always here to help.

--- a/android/src/main/java/expo/modules/nativewechat/ExpoNativeWechatModule.kt
+++ b/android/src/main/java/expo/modules/nativewechat/ExpoNativeWechatModule.kt
@@ -12,6 +12,7 @@ import com.tencent.mm.opensdk.modelbase.BaseReq
 import com.tencent.mm.opensdk.modelbase.BaseResp
 import com.tencent.mm.opensdk.modelbiz.SubscribeMessage
 import com.tencent.mm.opensdk.modelbiz.WXLaunchMiniProgram
+import com.tencent.mm.opensdk.modelbiz.WXOpenBusinessWebview
 import com.tencent.mm.opensdk.modelbiz.WXOpenCustomerServiceChat
 import com.tencent.mm.opensdk.modelmsg.SendAuth
 import com.tencent.mm.opensdk.modelmsg.SendMessageToWX
@@ -403,6 +404,22 @@ class ExpoNativeWechatModule : Module(), IWXAPIEventHandler {
             req.corpId = corpId
             req.url = url
 
+            sendEvent(
+                "ResponseData", bundleOf(
+                    "id" to params.id,
+                    "success" to wxApi?.sendReq(req)
+                )
+            )
+        }
+
+        Function("appPureSignContract") { params: AppPureSignContractParams ->
+            val req = WXOpenBusinessWebview.Req()
+            req.businessType = 12 // 固定值
+            
+            val queryInfo = HashMap<String, String>()
+            queryInfo["pre_entrustweb_id"] = params.preEntrustwebId
+            req.queryInfo = queryInfo
+            
             sendEvent(
                 "ResponseData", bundleOf(
                     "id" to params.id,

--- a/android/src/main/java/expo/modules/nativewechat/ExpoNativeWechatModuleParams.kt
+++ b/android/src/main/java/expo/modules/nativewechat/ExpoNativeWechatModuleParams.kt
@@ -196,3 +196,11 @@ class OpenCustomerServiceParams : Record {
   @Field
   val url: String = ""
 }
+
+class AppPureSignContractParams : Record {
+  @Field
+  val id: String = ""
+
+  @Field
+  val preEntrustwebId: String = ""
+}

--- a/ios/ExpoNativeWechatModule.swift
+++ b/ios/ExpoNativeWechatModule.swift
@@ -333,5 +333,19 @@ public class ExpoNativeWechatModule: Module {
                 self.sendEvent("ResponseData", ["id": params.id, "success": success])
             }
         }
+        
+        Function("appPureSignContract") { (params: AppPureSignContractParams) -> Void in
+            let req = WXOpenBusinessWebViewReq()
+            
+            req.businessType = 12 // 固定值
+            
+            var queryInfoDic = [String: String]()
+            queryInfoDic["pre_entrustweb_id"] = params.preEntrustwebId
+            req.queryInfoDic = queryInfoDic
+            
+            WXApi.send(req) { success in
+                self.sendEvent("ResponseData", ["id": params.id, "success": success])
+            }
+        }
     }
 }

--- a/ios/ExpoNativeWechatModuleParams.swift
+++ b/ios/ExpoNativeWechatModuleParams.swift
@@ -194,3 +194,11 @@ struct OpenCustomerServiceParams: Record {
     @Field
     var url: String
 }
+
+struct AppPureSignContractParams: Record {
+    @Field
+    var id: String
+    
+    @Field
+    var preEntrustwebId: String
+}

--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
     "expo": "*",
     "react": "*",
     "react-native": "*"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,22 @@ export const launchMiniProgram = (request: {
   });
 };
 
+export const appPureSignContract = (request: {
+  preEntrustwebId: string;
+}) => {
+  assertRegisteration("appPureSignContract");
+
+  return new Promise<boolean>((resolve, reject) => {
+    const id = executeNativeFunction(NativeModule.appPureSignContract)(request);
+
+    notification.once(id, (error, data) => {
+      if (error) reject(error);
+
+      resolve(data);
+    });
+  });
+};
+
 export const NativeWechatConstants =
   NativeModule.getConstants() as NativeWechatModuleConstants;
 


### PR DESCRIPTION
### Overview
This PR implements WeChat Pay's APP pure contract signing feature, enabling users to sign contracts directly through the WeChat client from external apps.

### What's Changed
- Added support for WeChat APP pure contract signing (APP纯签约)
- Implemented pre-signing API integration and contract signing workflow
- Added WeChat OpenBusinessWebview API support

### Implementation Details
The implementation follows WeChat Pay's official two-step process:

1. **Pre-signing API**: Backend calls to get `pre_entrustweb_id`
2. **Contract Signing**: App launches WeChat client with signing parameters

### Requirements
- OpenBusinessWebview permission from WeChat
- App registered on WeChat Open Platform
- WeChat SDK integration

### Reference Documentation
- [WeChat Pay APP Pure Contract Signing](https://pay.weixin.qq.com/doc/v2/merchant/4011986804)


